### PR TITLE
add basic Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/node_modules
+**/dist
+
+# Note that Vue config file is excluded from docker image
+vue.config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:lts-alpine
+
+RUN npm install -g http-server
+COPY ./script/dev.sh /
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+EXPOSE 8080
+CMD [ "http-server", "dist" ]

--- a/README.md
+++ b/README.md
@@ -32,3 +32,20 @@ npm run test:unit
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+## Docker
+
+Build sigma docker image:
+```
+docker build -t primevue/sigma . 
+```
+
+Run sigma docker image (navigate to http://localhost:8080/):
+```
+docker run -it -p 8080:8080 --rm --name sigma primevue/sigma
+```
+
+Run sigma docker image in dev mode:
+```
+docker run -it -p 8080:8080 -v $PWD:/app --rm --entrypoint="/dev.sh" --name sigma primevue/sigma
+```

--- a/script/dev.sh
+++ b/script/dev.sh
@@ -1,0 +1,2 @@
+#!/bin/ash
+npm install && npm run serve


### PR DESCRIPTION
This PR add to the project the ability to run under docker: no software is necessary to install previously (except docker obviously).

### Notes

Build sigma docker image:
```
docker build -t primevue/sigma . 
```

Run sigma docker image:
```
docker run -it -p 8080:8080 --rm --name sigma primevue/sigma
```
then navigate to http://localhost:8080/

If you want to develop with the project under docker you can mount the project to the docker image and run it in dev mode using the ```dev.sh``` script as entrypoint. You can run sigma docker image in dev mode with:
```
docker run -it -p 8080:8080 -v $PWD:/app --rm --entrypoint="/dev.sh" --name sigma primevue/sigma
```