### PR TITLE
Updated topbar. Added posibility to add Badges

### DIFF
--- a/src/assets/styles/sass/_topbar.scss
+++ b/src/assets/styles/sass/_topbar.scss
@@ -56,7 +56,7 @@
             font-size: 1.5rem;
         }
 
-        span {
+        & > span {
             font-size: 1rem;
             display: none;
         }
@@ -130,9 +130,16 @@
                 i {
                     font-size: 1rem;
                     margin-right: .5rem;
+
+                    & > span {
+                        font-size: 0.7rem;
+                        max-height: 1rem;
+                        min-width: 1rem;
+                        line-height: 1.1rem;
+                    }
                 }
 
-                span {
+                & > span {
                     font-weight: medium;
                     display: block;
                 }


### PR DESCRIPTION
Hi!! When trying to add Badges, the `span` nested tag was taking `display:none` property. This change allows you to add a badge inside an icon:
![image](https://user-images.githubusercontent.com/43607991/152694583-c1d7079a-6ac0-4839-a454-a84747607dca.png)
![image](https://user-images.githubusercontent.com/43607991/152694620-5440fccf-3fcb-409a-a826-5453a1746c38.png)
